### PR TITLE
 READMEの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*

--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# README
+## groups_usersテーブル
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -13,10 +13,10 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-|image|string|null: false, foreign_key: true|
-|text|text|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|image|string|
+|text|text|
 
 ### Association
 - belongs_to :group
@@ -26,22 +26,22 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, foreign_key: true|
-|email|string|null: false, foreign_key: true|
-|nickname|string|null: false, foreign_key: true|
-|password|string|null: false, foreign_key: true|
+|email|string|null: false|
+|nickname|string|null: false|
+|password|string|null: false|
 
 ### Association
 - has_many   :messages
+- has_many   :groups_users
 - has_many   :groups,through: :groups_users
 
 ## groupテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|message_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 
 ### Association
 - has_many   :messages
+- has_many   :groups_users
 - has_many   :users,through: :groups_users

--- a/README.md
+++ b/README.md
@@ -8,3 +8,39 @@
 ### Association
 - belongs_to :group
 - belongs_to :user
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|image|string|null: false, foreign_key: true|
+|body|text|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_id|integer|null: false, foreign_key: true|
+|image|string|null: false, foreign_key: true|
+|nickname|string|null: false, foreign_key: true|
+
+### Association
+- has_many   :messages
+- has_many   :groups,through: :groups_users
+
+## groupテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+
+
+### Association
+- has_many   :messages
+- has_many   :users,through: :groups_users

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 |image|string|null: false, foreign_key: true|
-|body|text|null: false, foreign_key: true|
+|text|text|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -27,8 +27,9 @@
 |Column|Type|Options|
 |------|----|-------|
 |group_id|integer|null: false, foreign_key: true|
-|image|string|null: false, foreign_key: true|
+|email|string|null: false, foreign_key: true|
 |nickname|string|null: false, foreign_key: true|
+|password|string|null: false, foreign_key: true|
 
 ### Association
 - has_many   :messages
@@ -39,7 +40,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
-
+|message_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many   :messages


### PR DESCRIPTION
#Whay
groups_usersテーブルの追加
user_id、group_idの追加
アソシエーション　belongs_to :group、belongs_to :userの追加

#Why
ChatSpaceでグループとユーザーの中間テーブルのため実装。